### PR TITLE
skip unless RELEASE_TESTING

### DIFF
--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -2,6 +2,10 @@ use strict;
 use warnings;
 use Test::More;
 
+unless ( $ENV{RELEASE_TESTING} ) {
+    plan( skip_all => "Author tests not required for installation" );
+}
+
 # Ensure a recent version of Test::Pod::Coverage
 my $min_tpc = 1.08;
 eval "use Test::Pod::Coverage $min_tpc";

--- a/t/pod.t
+++ b/t/pod.t
@@ -4,6 +4,10 @@ use strict;
 use warnings;
 use Test::More;
 
+unless ( $ENV{RELEASE_TESTING} ) {
+    plan( skip_all => "Author tests not required for installation" );
+}
+
 # Ensure a recent version of Test::Pod
 my $min_tp = 1.22;
 eval "use Test::Pod $min_tp";


### PR DESCRIPTION
Test::Pod::Coverage tests are more properly author, not everyone, tests, as
their failure does not imply code functionality failure...  just a lack of
documentation :)
