### PR TITLE
Changes for OFX style variation

### DIFF
--- a/Build.pl
+++ b/Build.pl
@@ -18,7 +18,7 @@ my $builder = Module::Build->new(
         'HTML::Parser'   => 0,
         'HTTP::Date'     => 0,
         'LWP'            => 0,
-        'File::Slurp'    => 0,
+        'File::Slurper'  => 0,
     },
     add_to_cleanup      => [ 'Finance-OFX-*' ],
     create_makefile_pl => 'traditional',

--- a/lib/Finance/OFX/Parse.pm
+++ b/lib/Finance/OFX/Parse.pm
@@ -103,6 +103,7 @@ sub parse
 
     # Parse the OFX header block
     $header =~ s/^\s//;				# Strip leading whitespace
+    $header =~ s/:\s+/:/g;          # Strip whitespace following a colon
     my %header = split /[:\n]/, $header;	# Convert to a hash
 
     return undef unless ($header{OFXHEADER} == '100') and ($header{DATA} eq 'OFXSGML');

--- a/lib/Finance/OFX/Parse.pm
+++ b/lib/Finance/OFX/Parse.pm
@@ -15,7 +15,7 @@ use warnings;
 
 our $VERSION = '2';
 
-use File::Slurp;
+use File::Slurper;
 use Finance::OFX::Tree;
 use HTTP::Date;
 
@@ -124,8 +124,7 @@ sub parse_file
 {
     my $file = shift;
     return undef unless $file;
-#    my $text = do { local(@ARGV, $/) = $file; <> };
-    my $text = read_file($file);
+    my $text = read_text($file);
     return undef unless $text;
     return parse($text);
 }


### PR DESCRIPTION
I found a vendor who provides files which used spaces in the heading and closed many of the text field tags.

Also, changed to File::Slurper (from File::Slurp) due to the increased safety of that other function.
