### PR TITLE
Include CDATA in dtext

### DIFF
--- a/lib/Finance/OFX/Tree.pm
+++ b/lib/Finance/OFX/Tree.pm
@@ -53,6 +53,7 @@ sub parse
 			@{$stack[0]}[-1]->{content} = $data;
 		    }, 'dtext' ]);
     $p->unbroken_text(1);   # Want element contents in single blocks to facilitate parsing
+    $p->marked_sections(1);
     $p->parse($source);
     \@tree;
 }


### PR DESCRIPTION
Some institutions encode text as CDATA; this commit instructs HTML::Parser to add it to the text.